### PR TITLE
Add Optional Flags For Make Class Command

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,36 +20,29 @@ You're all set. Run php artisan from the console, and you'll see the new command
 - make:trait
 
 ## Usage
-### Creating A PHP Class
+Here's a few other examples of commands that you might write:
+
 ``` bash
 php artisan make:class Services/EmailForwarderService
 ```
-This `EmailForwarderService` class will be generated under the `App/Services` namespace and the directory will be automatically created if it does not exist.
-
-
-### Creating An Abstract Class
-You can generate an abstract class by calling the artisan `make:abstract-class` command followed by the name of the class. 
 ``` bash
 php artisan make:abstract-class Services/AbstractEmailForwarder
 ```
-By default, all traits are generated under the `App/Services` namespace.
-
-### Creating An Interface
-You can generate an interface by calling the artisan `make:interface` command followed by the name of the class. 
 ``` bash
-php artisan make:abstract-class Services/AbstractEmailForwarder
+php artisan make:interface EmailForwarderContract
 ```
-By default, all interfaces are generated under the `App/Contracts` namespace.
-
-### Creating A Trait
-You can generate a trait by calling the artisan `make:trait` command followed by the name of the trait. 
 ``` bash
 php artisan make:trait FileUpload
 ```
-By default, all traits are generated under the `App/Traits` namespace and the directory will be automatically created if it does not exist.
-
 ### Option for all the commands
 --force This will overide the existing file, if it exist
+
+### Default Namespaces
+ - All interfaces are generated under the `App/Contracts` namespace.
+ - All traits are generated under the `App/Traits` namespace.
+ - Classes and abstract classes are generated under the `App` namespace.
+
+Default namespaces can be configured inside the package config file. 
 
 ## Configurations
 You can configure default namespace by publishing the package config file:

--- a/README.md
+++ b/README.md
@@ -43,6 +43,17 @@ php artisan make:trait FileUpload
 - `--abstract` OR `-c` This will generate an abstract class for the generated class. 
 - `--all` OR `-a` This will generate an interface, a trait and an abstract class for the generated class. 
 
+#### Example:
+This will generate an interface for this class.
+```bash
+php artisan make:class Services/EmailForwarderService --interface
+```
+
+This will generate a trait for this class.
+```bash
+php artisan make:class Services/EmailForwarderService --trait
+```
+
 ### Default Namespaces
  - All interfaces are generated under the `App/Contracts` namespace.
  - All traits are generated under the `App/Traits` namespace.

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 
 Have you ever enjoyed the assistance of artisan commands? This package brings more of it :)
 
-You can now generate PHP classes and traits using artisan `make:class`, `make:abstract-class`, `make:interface` or `make:trait` console commands.
+You can now generate PHP classes and traits using artisan `make:class`,  `make:interface`, `make:trait` or `make:abstract-class` console commands.
 
 ## Installation
 ### Step 1: Install Through Composer
@@ -15,9 +15,9 @@ composer require stephenjude/extended-artisan-commands --dev
 ### Step 2: Run Artisan!
 You're all set. Run php artisan from the console, and you'll see the new commands in the make:* namespace section.
 - make:class
-- make:abstract-class
 - make:interface
 - make:trait
+- make:abstract-class
 
 ## Usage
 Here's a few other examples of commands that you might write:
@@ -36,6 +36,12 @@ php artisan make:trait FileUpload
 ```
 ### Option for all the commands
 --force This will overide the existing file, if it exist
+
+### Options for the `make:class` command
+- `--interface` OR `-i` This will generate an interface for the generated class. 
+- `--trait` OR `-t` This will generate a trait for the generated class. 
+- `--abstract` OR `-c` This will generate an abstract class for the generated class. 
+- `--all` OR `-a` This will generate an interface, a trait and an abstract class for the generated class. 
 
 ### Default Namespaces
  - All interfaces are generated under the `App/Contracts` namespace.

--- a/src/Concerns/WithAbstractClass.php
+++ b/src/Concerns/WithAbstractClass.php
@@ -1,0 +1,72 @@
+<?php
+
+namespace Stephenjude\ExtendedArtisanCommands\Concerns;
+
+use Illuminate\Support\Str;
+
+trait WithAbstractClass
+{
+    /**
+     * Prefix for abstract class name
+     *
+     * @var string
+     */
+    protected $classPrefix = 'Abstract';
+
+    /**
+     * Create an abstract class for the class.
+     *
+     * @return void
+     */
+    protected function createAbstractClass()
+    {
+
+        $className = $this->argument('name');
+
+        $name = $this->qualifyClass($className);
+
+        $baseName = class_basename($className);
+
+        $alias = $this->classPrefix.$baseName;
+
+        $abstractClass = Str::studly(str_replace($baseName, $alias,  $name));
+
+        $this->call('make:abstract-class', [
+            'name' => "{$abstractClass}",
+        ]);
+    }
+
+    /**
+     * Replace the abstract class name for the given stub.
+     *
+     * @param  string  $stub
+     * @return string
+     */
+    protected function replaceAbstractClassStubs($stub) : string
+    {
+        $alias = $this->classPrefix.$this->className;
+
+        $namespace = $this->getAbstractClassNamespace($alias);
+
+        $stub = str_replace('DummyAbstractClassNamespace', $namespace, $stub);
+
+        $stub = str_replace('DummyAbstractClass', $alias, $stub);
+
+        return $stub;
+    }
+
+    /**
+     * Parse the abstract class name and format according to abstract class root namespace.
+     *
+     * @param  string  $name
+     * @return string
+     */
+    protected function getAbstractClassNamespace($name): string
+    {
+        $namespace = $this->rootNamespace().config('extended-artisan-commands.abstract_namespace')."\\$name";
+
+        return str_replace('\\\\', '\\', $namespace);
+    }
+}
+
+

--- a/src/Concerns/WithInterface.php
+++ b/src/Concerns/WithInterface.php
@@ -1,0 +1,61 @@
+<?php
+
+namespace Stephenjude\ExtendedArtisanCommands\Concerns;
+
+use Illuminate\Support\Str;
+
+trait WithInterface
+{
+    /**
+     * Prefix for using interface in a class
+     *
+     * @var string
+     */
+    protected $suffix = 'Contract';
+
+    /**
+     * Create an interface for the class.
+     *
+     * @return void
+     */
+    protected function createInterface()
+    {
+        $interface = Str::studly(class_basename($this->argument('name')));
+
+        $this->call('make:interface', [
+            'name' => "{$interface}",
+        ]);
+    }
+
+    /**
+     * Replace the interface name for the given stub.
+     *
+     * @param  string  $stub
+     * @return string
+     */
+    protected function replaceInterfaceStubs($stub) : string
+    {
+        $namespace = $this->getInterfaceNamespace($this->className);
+
+        $alias = $this->className.$this->suffix;
+
+        $stub = str_replace('DummyInterfaceNamespace', "$namespace as $alias", $stub);
+
+        $stub = str_replace('DummyInterface', $alias, $stub);
+
+        return $stub;
+    }
+
+    /**
+     * Parse the interface name and format according to interface root namespace.
+     *
+     * @param  string  $name
+     * @return string
+     */
+    protected function getInterfaceNamespace($name): string
+    {
+        $namespace = $this->rootNamespace().config('extended-artisan-commands.interface_namespace')."\\$name";
+
+        return str_replace('\\\\', '\\', $namespace);
+    }
+}

--- a/src/Concerns/WithStubCleaner.php
+++ b/src/Concerns/WithStubCleaner.php
@@ -1,0 +1,49 @@
+<?php
+
+namespace Stephenjude\ExtendedArtisanCommands\Concerns;
+
+trait WithStubCleaner
+{
+    protected function cleanStubs($stub) : string
+    {
+        if ($this->option('all')) {
+            return $stub;
+        }
+
+        $stub = $this->cleanTraitStub($stub);
+        $stub = $this->cleanInterfaceStub($stub);
+        $stub = $this->cleanAbstractClassStub($stub);
+
+        $stub = preg_replace('/\n\n\n/', PHP_EOL.PHP_EOL, $stub);
+        $stub = preg_replace('/\n\n\n\n/', PHP_EOL, $stub);
+
+        return $stub;
+    }
+
+    public function cleanTraitStub($stub) : string
+    {
+        if (! $this->option('trait')) {
+            $stub = str_replace('use DummyTraitNamespace;', '', $stub);
+            $stub = str_replace('   use DummyTrait;', '', $stub);
+        }
+        return $stub;
+    }
+
+    public function cleanInterfaceStub($stub) : string
+    {
+        if (! $this->option('interface')) {
+            $stub = str_replace('use DummyInterfaceNamespace;', '', $stub);
+            $stub = str_replace('implements DummyInterface', '', $stub);
+        }
+        return $stub;
+    }
+
+    public function cleanAbstractClassStub($stub) : string
+    {
+        if (! $this->option('abstract')) {
+            $stub = str_replace('use DummyAbstractClassNamespace;', '', $stub);
+            $stub = str_replace('extends DummyAbstractClass ', '', $stub);
+        }
+        return $stub;
+    }
+}

--- a/src/Concerns/WithTrait.php
+++ b/src/Concerns/WithTrait.php
@@ -1,0 +1,56 @@
+<?php
+
+namespace Stephenjude\ExtendedArtisanCommands\Concerns;
+
+use Illuminate\Support\Str;
+
+trait WithTrait
+{
+    /**
+     * Create an trait for the class.
+     *
+     * @return void
+     */
+    protected function createTrait()
+    {
+        $trait = Str::studly(class_basename($this->argument('name')));
+
+        $this->call('make:trait', [
+            'name' => "{$trait}",
+        ]);
+    }
+
+    /**
+     * Replace the trait name for the given stub.
+     *
+     * @param  string  $stub
+     * @return string
+     */
+    protected function replaceTraitStubs($stub) : string
+    {
+        $namespace = $this->getTraitNamespace($this->className);
+
+        $alias = $this->className.'Trait';
+
+        $useTrait = "$namespace as $alias";
+
+        $stub = str_replace('DummyTraitNamespace', $useTrait, $stub);
+
+        $stub = str_replace('DummyTrait', $alias, $stub);
+
+        return $stub;
+    }
+
+    /**
+     * Parse the trait name and format according to trait root namespace.
+     *
+     * @param  string  $name
+     * @return string
+     */
+    protected function getTraitNamespace($name): string
+    {
+        $namespace = $this->rootNamespace().config('extended-artisan-commands.trait_namespace')."\\$name";
+
+        return str_replace('\\\\', '\\', $namespace);
+    }
+}

--- a/src/stubs/class.stub
+++ b/src/stubs/class.stub
@@ -2,12 +2,13 @@
 
 namespace DummyNamespace;
 
-class DummyClass
-{
-    public function __construct()
-    {
+use DummyTraitNamespace;
+use DummyInterfaceNamespace;
+use DummyAbstractClassNamespace;
 
-    }
+class DummyClass extends DummyAbstractClass implements DummyInterface
+{
+    use DummyTrait;
 }
 
 

--- a/tests/MakeAbstractClassTest.php
+++ b/tests/MakeAbstractClassTest.php
@@ -7,7 +7,7 @@ class MakeAbstractClassTest extends TestCase
     public function test_make_abstarct_class()
     {
         $this->artisan('make:abstract-class Services/CommandGenerator')
-            ->expectsOutput('Abstract Class created successfully.')
+            ->expectsOutput($this->abstractClassConsoleOutput)
             ->assertExitCode(0);
     }
 }

--- a/tests/MakeClassTest.php
+++ b/tests/MakeClassTest.php
@@ -7,8 +7,43 @@ class MakeClassTest extends TestCase
     /** @test */
     public function test_make_class()
     {
-        $this->artisan('make:class Services/EmailService')
-            ->expectsOutput('Class created successfully.')
+        $this->artisan('make:class Services/FileService')
+            ->expectsOutput($this->classConsoleOutput)
+            ->assertExitCode(0);
+    }
+
+    /** @test */
+    public function test_make_class_with_interface_flag()
+    {
+        $this->artisan('make:class Services/FileUploadService -i')
+            ->expectsOutput($this->classConsoleOutput)
+            ->expectsOutput($this->interfaceConsoleOutput)
+            ->assertExitCode(0);
+    }
+
+    public function test_make_class_with_trait_flag()
+    {
+        $this->artisan('make:class Services/FileDownloadService -t')
+            ->expectsOutput($this->classConsoleOutput)
+            ->expectsOutput($this->traitConsoleOutput)
+            ->assertExitCode(0);
+    }
+
+    public function test_make_class_with_abstract_class_flag()
+    {
+        $this->artisan('make:class Services/FileReloadService -c')
+            ->expectsOutput($this->classConsoleOutput)
+            ->expectsOutput($this->abstractClassConsoleOutput)
+            ->assertExitCode(0);
+    }
+
+    public function test_make_class_with_all_flag()
+    {
+        $this->artisan('make:class Services/FileDeleteService -a')
+            ->expectsOutput($this->classConsoleOutput)
+            ->expectsOutput($this->interfaceConsoleOutput)
+            ->expectsOutput($this->abstractClassConsoleOutput)
+            ->expectsOutput($this->traitConsoleOutput)
             ->assertExitCode(0);
     }
 }

--- a/tests/MakeInterfaceTest.php
+++ b/tests/MakeInterfaceTest.php
@@ -10,7 +10,7 @@ class MakeInterfaceTest extends TestCase
     public function test_make_interface()
     {
         $this->artisan('make:interface EmailContract')
-            ->expectsOutput('Interface created successfully.')
+            ->expectsOutput($this->interfaceConsoleOutput)
             ->assertExitCode(0);
     }
 }

--- a/tests/MakeTraitTest.php
+++ b/tests/MakeTraitTest.php
@@ -8,7 +8,7 @@ class MakeTraitTest extends TestCase
     public function test_make_trait()
     {
         $this->artisan('make:trait FileUpload')
-            ->expectsOutput('Trait created successfully.')
+            ->expectsOutput($this->traitConsoleOutput)
             ->assertExitCode(0);
     }
 

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -8,6 +8,35 @@ use Stephenjude\ExtendedArtisanCommands\ExtendedArtisanCommandsServiceProvider;
 
 class TestCase extends Orchestra
 {
+    /**
+     * Console output for make:interface command
+     *
+     * @var string
+     */
+    protected $interfaceConsoleOutput = "Interface created successfully.";
+
+    /**
+     * Console output for make:trait command
+     *
+     * @var string
+     */
+    protected $traitConsoleOutput = "Trait created successfully.";
+
+    /**
+     * Console output for make:class command
+     *
+     * @var string
+     */
+    protected $classConsoleOutput = "Class created successfully.";
+
+
+    /**
+     * Console output for make:abstract-class command
+     *
+     * @var string
+     */
+    protected $abstractClassConsoleOutput = "Abstract Class created successfully.";
+
     public function setUp() : void
     {
         parent::setUp();
@@ -18,17 +47,6 @@ class TestCase extends Orchestra
     protected function getPackageProviders($app)
     {
         return [ExtendedArtisanCommandsServiceProvider::class];
-    }
-
-    private function cleanOutputDirectory() : void
-    {
-        /**
-         *  Remove known files while suppressing errors
-         */
-        @unlink(app_path('Contracts/EmailContract.php'));
-        @unlink(app_path('Traits/FileUpload.php'));
-        @unlink(app_path('Services/CommandGenerator.php'));
-        @unlink(app_path('Services/EmailService.php'));
     }
 
     /**
@@ -43,5 +61,10 @@ class TestCase extends Orchestra
         $app['config']->set('extended-artisan-commands.abstract_class_namespace', '');
         $app['config']->set('extended-artisan-commands.interface_namespace', '\Contracts');
         $app['config']->set('extended-artisan-commands.trait_namespace', '\Traits');
+    }
+
+    private function cleanOutputDirectory() : void
+    {
+         File::deleteDirectory(base_path('app'));
     }
 }


### PR DESCRIPTION
This PR adds optional flags for generating additional files for the `make:class` command.
- Added Optional flags.
    - `--interface` OR `-i` This will generate an interface for the generated class. 
    - `--trait` OR `-t` This will generate a trait for the generated class. 
    - `--abstract` OR `-c` This will generate an abstract class for the generated class. 
    - `--all` OR `-a` This will generate an interface, a trait and an abstract class for the generated class.
- Add Usage Guide
- Tests

#### Example:
This will create a trait for the generated class.
```bash
php artisan make:class Services/EmailForwarderService --trait
```